### PR TITLE
Some minor LND updates mostly etcd related

### DIFF
--- a/docker-compose-etcd-notls.yml
+++ b/docker-compose-etcd-notls.yml
@@ -1,0 +1,75 @@
+version: '3.4'
+services:
+  bitcoind:
+    image: kylemanna/bitcoind
+    volumes:
+      - ./bitcoin.conf:/bitcoin/.bitcoin/bitcoin.conf
+
+  etcd-alice:
+    restart: unless-stopped
+    image: 'bitnami/etcd:3.4.16'
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
+      - ETCD_ADVERTISE_CLIENT_URLS=http://0.0.0.0:2379
+      - ETCD_MAX_TXN_OPS=16384
+      - ETCD_MAX_REQUEST_BYTES=104857600
+
+  etcd-bob:
+    restart: unless-stopped
+    image: 'bitnami/etcd:3.4.16'
+    environment:
+      - ALLOW_NONE_AUTHENTICATION=yes
+      - ETCD_LISTEN_CLIENT_URLS=http://0.0.0.0:2379
+      - ETCD_ADVERTISE_CLIENT_URLS=http://0.0.0.0:2379
+      - ETCD_MAX_TXN_OPS=16384
+      - ETCD_MAX_REQUEST_BYTES=104857600
+
+  lnd-alice:
+    restart: unless-stopped
+    build: 
+      context: lnd
+      args:
+        checkout: v0.13.0-beta.rc5
+        tags: signrpc walletrpc chainrpc invoicesrpc monitoring kvdb_etcd
+    depends_on:
+      - bitcoind
+      - etcd-alice
+    volumes:
+      - ./lnd.conf:/root/.lnd/lnd.conf
+      - lnd-alice:/cfg
+    ports:
+      - 5000:5000      
+    command: --tlsextradomain=lnd-alice --db.backend=etcd --db.etcd.host=etcd-alice:2379 --db.etcd.disabletls
+
+  lnd-bob:
+    restart: unless-stopped
+    build: 
+      context: lnd
+      args:
+        checkout: v0.13.0-beta.rc5
+        tags: signrpc walletrpc chainrpc invoicesrpc monitoring kvdb_etcd
+    depends_on:
+      - bitcoind
+      - etcd-bob
+    volumes:
+      - ./lnd.conf:/root/.lnd/lnd.conf
+      - lnd-bob:/cfg
+    ports:
+      - 5001:5000      
+    command: --tlsextradomain=lnd-bob --db.backend=etcd --db.etcd.host=etcd-bob:2379 --db.etcd.disabletls
+
+  loadtest:
+    build: loadtest
+    depends_on:
+      - lnd-alice
+      - lnd-bob
+    volumes:
+      - lnd-alice:/lnd-alice
+      - lnd-bob:/lnd-bob
+      - ./${LOADTEST_CONFIG_FILE}:/loadtest.yml
+ 
+volumes:
+  lnd-alice:
+  lnd-bob:
+    

--- a/docker-compose-etcd.yml
+++ b/docker-compose-etcd.yml
@@ -7,7 +7,7 @@ services:
 
   etcd-alice:
     restart: unless-stopped
-    image: 'bitnami/etcd:3.3.10'
+    image: 'bitnami/etcd:3.4.16'
     environment:
       - ALLOW_NONE_AUTHENTICATION=yes
       - ETCD_LISTEN_CLIENT_URLS=https://0.0.0.0:2379
@@ -18,7 +18,7 @@ services:
 
   etcd-bob:
     restart: unless-stopped
-    image: 'bitnami/etcd:3.3.10'
+    image: 'bitnami/etcd:3.4.16'
     environment:
       - ALLOW_NONE_AUTHENTICATION=yes
       - ETCD_LISTEN_CLIENT_URLS=https://0.0.0.0:2379
@@ -32,7 +32,7 @@ services:
     build: 
       context: lnd
       args:
-        checkout: v0.12.1-beta
+        checkout: v0.13.0-beta.rc5
         tags: signrpc walletrpc chainrpc invoicesrpc monitoring kvdb_etcd
     depends_on:
       - bitcoind
@@ -49,7 +49,7 @@ services:
     build: 
       context: lnd
       args:
-        checkout: v0.12.1-beta
+        checkout: v0.13.0-beta.rc5
         tags: signrpc walletrpc chainrpc invoicesrpc monitoring kvdb_etcd
     depends_on:
       - bitcoind
@@ -74,4 +74,4 @@ services:
 volumes:
   lnd-alice:
   lnd-bob:
-    
+

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 if [[ $1 == "" ]]
 then
-  echo "usage: run.sh lnd-bbolt | lnd-bbolt-keysend | lnd-etcd | lnd-etcd-cluster | clightning | eclair"
+  echo "usage: run.sh lnd-bbolt | lnd-bbolt-keysend | lnd-etcd | lnd-etcd-notls | lnd-etcd-notls-keysend | lnd-etcd-cluster | clightning | eclair"
   exit 0
 fi
 
@@ -20,6 +20,16 @@ case $1 in
   "lnd-etcd")
     DOCKER_COMPOSE_FILE=docker-compose-etcd.yml
     export LOADTEST_CONFIG_FILE=loadtest-lnd.yml
+    ;;
+  
+  "lnd-etcd-notls")
+    DOCKER_COMPOSE_FILE=docker-compose-etcd-notls.yml
+    export LOADTEST_CONFIG_FILE=loadtest-lnd.yml
+    ;;
+  
+  "lnd-etcd-notls-keysend")
+    DOCKER_COMPOSE_FILE=docker-compose-etcd-notls.yml
+    export LOADTEST_CONFIG_FILE=loadtest-lnd-keysend.yml
     ;;
 
   "lnd-etcd-cluster")


### PR DESCRIPTION
Hi Bottlepay,

Ran a few benchmarks and for the etcd case it seems like a bunch CPU of time is spent in the TLS layer. I thought it'd be an interesting comparison vs the experimental postgres kvdb driver since it also doesn't use TLS at the moment. PTAL.

For reference, on my Hetzner cloud instance (AX-41-NVMe) the first few data points are:

```
lnd-etcd:
loadtest_1    | 2021-06-09T15:34:50.613Z	INFO	Speed	{"tps": 34.91778994137819, "count": 1000, "avg_latency_sec": 2.173053539867}
loadtest_1    | 2021-06-09T15:35:17.765Z	INFO	Speed	{"tps": 36.82955991150079, "count": 2000, "avg_latency_sec": 2.65595066485}
loadtest_1    | 2021-06-09T15:35:49.353Z	INFO	Speed	{"tps": 31.65781099648854, "count": 3000, "avg_latency_sec": 3.169215847652}
loadtest_1    | 2021-06-09T15:36:27.265Z	INFO	Speed	{"tps": 26.377218947832528, "count": 4000, "avg_latency_sec": 3.757643285047}

lnd-etcd-notls:
loadtest_1    | 2021-06-09T15:37:41.833Z	INFO	Speed	{"tps": 48.286619587525784, "count": 1000, "avg_latency_sec": 1.71128064486}
loadtest_1    | 2021-06-09T15:38:04.166Z	INFO	Speed	{"tps": 44.77649111135035, "count": 2000, "avg_latency_sec": 2.2084367948590002}
loadtest_1    | 2021-06-09T15:38:30.885Z	INFO	Speed	{"tps": 37.426390145914446, "count": 3000, "avg_latency_sec": 2.6139758464010003}
loadtest_1    | 2021-06-09T15:39:02.952Z	INFO	Speed	{"tps": 31.18514511811111, "count": 4000, "avg_latency_sec": 3.1428967239600003}

lnd-bbolt:
loadtest_1   | 2021-06-09T15:39:52.502Z	INFO	Speed	{"tps": 68.06800270016427, "count": 1000, "avg_latency_sec": 1.340028921759}
loadtest_1   | 2021-06-09T15:40:06.561Z	INFO	Speed	{"tps": 71.13055166118907, "count": 2000, "avg_latency_sec": 1.409935852396}
loadtest_1   | 2021-06-09T15:40:20.167Z	INFO	Speed	{"tps": 73.50000971254853, "count": 3000, "avg_latency_sec": 1.3745317160269999}
loadtest_1   | 2021-06-09T15:40:43.643Z	INFO	Speed	{"tps": 42.59649525501131, "count": 4000, "avg_latency_sec": 2.2255254259100004}```

