### PR TITLE
Use eclair 0.6.1 and add postgres backend

### DIFF
--- a/docker-compose-eclair-postgres.yml
+++ b/docker-compose-eclair-postgres.yml
@@ -7,7 +7,7 @@ services:
 
   postgres-alice:
     restart: unless-stopped
-    image: postgres
+    image: postgres:13
     environment:
       POSTGRES_DB: eclair
       POSTGRES_USER: pguser
@@ -15,7 +15,7 @@ services:
 
   postgres-bob:
     restart: unless-stopped
-    image: postgres
+    image: postgres:13
     environment:
       POSTGRES_DB: eclair
       POSTGRES_USER: pguser

--- a/docker-compose-eclair-postgres.yml
+++ b/docker-compose-eclair-postgres.yml
@@ -1,0 +1,51 @@
+version: '3.4'
+services:
+  bitcoind:
+    image: kylemanna/bitcoind
+    volumes:
+      - ./bitcoin.conf:/bitcoin/.bitcoin/bitcoin.conf
+
+  postgres-alice:
+    restart: unless-stopped
+    image: postgres
+    environment:
+      POSTGRES_DB: eclair
+      POSTGRES_USER: pguser
+      POSTGRES_PASSWORD: pgpassword
+
+  postgres-bob:
+    restart: unless-stopped
+    image: postgres
+    environment:
+      POSTGRES_DB: eclair
+      POSTGRES_USER: pguser
+      POSTGRES_PASSWORD: pgpassword
+
+  eclair-alice:
+    restart: unless-stopped
+    image: acinq/eclair:release-0.6.1
+    depends_on:
+      - bitcoind
+      - postgres-alice
+    volumes:
+      - ./eclair/eclair.conf:/data/eclair.conf
+      - ./eclair/logback.xml:/data/logback.xml
+    environment:
+      JAVA_OPTS: -Dlogback.configurationFile=/data/logback.xml -Declair.db.driver=postgres -Declair.db.postgres.host=postgres-alice
+
+  eclair-bob:
+    restart: unless-stopped
+    image: acinq/eclair:release-0.6.1
+    depends_on:
+      - bitcoind
+      - postgres-bob
+    volumes:
+      - ./eclair/eclair.conf:/data/eclair.conf
+      - ./eclair/logback.xml:/data/logback.xml
+    environment:
+      JAVA_OPTS: -Dlogback.configurationFile=/data/logback.xml -Declair.db.driver=postgres -Declair.db.postgres.host=postgres-bob
+
+  loadtest:
+     build: loadtest
+     volumes:
+       - ./${LOADTEST_CONFIG_FILE}:/loadtest.yml

--- a/docker-compose-eclair.yml
+++ b/docker-compose-eclair.yml
@@ -7,19 +7,26 @@ services:
 
   eclair-alice:
     restart: unless-stopped
-    image: acinq/eclair:release-0.5.1
+    image: acinq/eclair:release-0.6.1
     depends_on:
       - bitcoind
     volumes:
-      - ./eclair.conf:/data/eclair.conf
+      - ./eclair/eclair.conf:/data/eclair.conf
+      - ./eclair/logback.xml:/data/logback.xml
+    environment:
+      JAVA_OPTS: -Dlogback.configurationFile=/data/logback.xml
+
 
   eclair-bob:
     restart: unless-stopped
-    image: acinq/eclair:release-0.5.1
+    image: acinq/eclair:release-0.6.1
     depends_on:
       - bitcoind
     volumes:
-      - ./eclair.conf:/data/eclair.conf
+      - ./eclair/eclair.conf:/data/eclair.conf
+      - ./eclair/logback.xml:/data/logback.xml
+    environment:
+      JAVA_OPTS: -Dlogback.configurationFile=/data/logback.xml
 
   loadtest:
      build: loadtest

--- a/eclair/eclair.conf
+++ b/eclair/eclair.conf
@@ -17,5 +17,9 @@ eclair.bitcoind.zmqtx="tcp://bitcoind:29333"
 eclair.bitcoind.host="bitcoind"
 eclair.bitcoind.rpcport=8332
 
-eclair.file-backup.enabled=false
 eclair.max-accepted-htlcs=483
+
+eclair.file-backup.enabled=false
+
+eclair.db.postgres.username=pguser
+eclair.db.postgres.password=pgpassword

--- a/eclair/eclair.conf
+++ b/eclair/eclair.conf
@@ -17,4 +17,5 @@ eclair.bitcoind.zmqtx="tcp://bitcoind:29333"
 eclair.bitcoind.host="bitcoind"
 eclair.bitcoind.rpcport=8332
 
-eclair.enable-db-backup=false
+eclair.file-backup.enabled=false
+eclair.max-accepted-htlcs=483

--- a/eclair/logback.xml
+++ b/eclair/logback.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <target>System.out</target>
+        <withJansi>false</withJansi>
+        <encoder>
+            <pattern>%yellow(${HOSTNAME} %d) %highlight(%-5level) %replace(%logger{24}){'\$.*',''}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{12}%n</pattern>
+        </encoder>
+    </appender>
+
+    <appender name="ROLLING" class="ch.qos.logback.core.rolling.RollingFileAppender">
+        <file>${eclair.datadir:-${user.home}/.eclair}/eclair.log</file>
+        <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+            <!-- daily rollover -->
+            <fileNamePattern>${eclair.datadir:-${user.home}/.eclair}/eclair.%d{yyyy-MM-dd}.log</fileNamePattern>
+            <!-- keep 90 days' worth of history capped at 5 GB total size -->
+            <maxHistory>90</maxHistory>
+            <totalSizeCap>5GB</totalSizeCap>
+        </rollingPolicy>
+        <encoder>
+            <pattern>%d %-5level %replace(%logger{24}){'\$.*',''}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{24}%n</pattern>
+        </encoder>
+    </appender>
+
+    <if condition='isDefined("eclair.printToConsole")'>
+        <then>
+            <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+                <encoder>
+                    <pattern>%d %-5level %replace(%logger{24}){'\$.*',''}%X{category}%X{nodeId}%X{channelId}%X{paymentHash}%.-11X{parentPaymentId}%.-11X{paymentId} - %msg%ex{24}%n</pattern>
+                </encoder>
+            </appender>
+            <root>
+                <appender-ref ref="CONSOLE"/>
+            </root>
+        </then>
+    </if>
+
+    <logger name="fr.acinq.eclair.Setup" level="INFO" />
+
+    <root level="WARN">
+        <appender-ref ref="ROLLING"/>
+    </root>
+
+</configuration>

--- a/loadtest-eclair.yml
+++ b/loadtest-eclair.yml
@@ -13,6 +13,6 @@ receiver:
     rpcHost: eclair-bob:8081
     password: test
 paymentAmountMsat: 1000
-processes: 10
+processes: 100
 channels: 10
 channelCapacitySat: 10000000

--- a/run.sh
+++ b/run.sh
@@ -37,6 +37,11 @@ case $1 in
     export LOADTEST_CONFIG_FILE=loadtest-eclair.yml
     ;;
 
+  "eclair-postgres")
+    DOCKER_COMPOSE_FILE=docker-compose-eclair-postgres.yml
+    export LOADTEST_CONFIG_FILE=loadtest-eclair.yml
+    ;;
+
   *)
     echo "unknown configuration"
     exit 1

--- a/run.sh
+++ b/run.sh
@@ -2,7 +2,7 @@
 
 if [[ $1 == "" ]]
 then
-  echo "usage: run.sh lnd-bbolt | lnd-bbolt-keysend | lnd-etcd | lnd-etcd-cluster | clightning | eclair"
+  echo "usage: run.sh lnd-bbolt | lnd-bbolt-keysend | lnd-etcd | lnd-etcd-cluster | clightning | eclair | eclair-postgres"
   exit 0
 fi
 


### PR DESCRIPTION
Eclair 0.6.1 uses WAL mode in sqlite and other parallelization
improvements which should increase performance by more than 5x.

Also, reorganized eclair files a little bit and set more sensible log
levels. We were using the default log settings, which are very verbose. It's
great for debug, but not appropriate in a performance benchmark setting.

Add support for the postgres backend with eclair, using `./run eclair-postgres`.