### PR TITLE
allow dynamic config file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ To display the profile in a browser, run:
 
 ## Configuration
 
-The `loadtest` container reads test parameters from the file `loadtest.yml` the
+The `loadtest` container reads test parameters from the file `loadtest.yml` (or the filename specified in the `CONFIG_FILE` environment variable) the
 following parameters are available:
 
 * `paymentAmountMsat`: the test amount that is paid

--- a/loadtest/config.go
+++ b/loadtest/config.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"io/ioutil"
+	"os"
 
 	"gopkg.in/yaml.v2"
 )
@@ -48,7 +49,11 @@ type config struct {
 }
 
 func loadConfig() (*config, error) {
-	yamlFile, err := ioutil.ReadFile("loadtest.yml")
+	configFile := os.Getenv("CONFIG_FILE")
+	if configFile == "" {
+		configFile = "loadtest.yaml"
+	}
+	yamlFile, err := ioutil.ReadFile(configFile)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
I'm trying to run this on k8s, but you can't mount a config file in the root `/` of the container, so I needed to make the config file location customizable.